### PR TITLE
update version tag to v0.0.2

### DIFF
--- a/build/package/nodejs/go.mod
+++ b/build/package/nodejs/go.mod
@@ -2,4 +2,4 @@ module github.com/teamsnap/node-vault
 
 go 1.13
 
-require github.com/teamsnap/vault-key/pkg/vault v0.0.1
+require github.com/teamsnap/vault-key/pkg/vault v0.0.2

--- a/build/package/ruby/go.mod
+++ b/build/package/ruby/go.mod
@@ -2,4 +2,4 @@ module github.com/teamsnap/ruby-vault
 
 go 1.13
 
-require github.com/teamsnap/vault-key/pkg/vault v0.0.1
+require github.com/teamsnap/vault-key/pkg/vault v0.0.2

--- a/cmd/vault-init/go.mod
+++ b/cmd/vault-init/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/sirupsen/logrus v1.4.2
-	github.com/teamsnap/vault-key/pkg/vault v0.0.1 // indirect
+	github.com/teamsnap/vault-key/pkg/vault v0.0.2 // indirect
 )

--- a/cmd/vault-k8s-secret/go.mod
+++ b/cmd/vault-k8s-secret/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/sirupsen/logrus v1.4.2
-	github.com/teamsnap/vault-key/pkg/k8s v0.0.1
-	github.com/teamsnap/vault-key/pkg/vault v0.0.1 // indirect
+	github.com/teamsnap/vault-key/pkg/k8s v0.0.2
+	github.com/teamsnap/vault-key/pkg/vault v0.0.2 // indirect
 )

--- a/examples/go/google-cloud-functions/go.mod
+++ b/examples/go/google-cloud-functions/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/rogpeppe/go-internal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/teamsnap/vault-key/pkg/vault v0.0.1
+	github.com/teamsnap/vault-key/pkg/vault v0.0.2
 	go.opencensus.io v0.22.0
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 // indirect
 	golang.org/x/exp v0.0.0-20190829153037-c13cbed26979 // indirect

--- a/examples/go/non-gcp-environment/go.mod
+++ b/examples/go/non-gcp-environment/go.mod
@@ -2,4 +2,4 @@ module github.com/teamsnap/gcf
 
 go 1.13
 
-require github.com/teamsnap/vault-key/pkg/vault v0.0.1
+require github.com/teamsnap/vault-key/pkg/vault v0.0.2


### PR DESCRIPTION
Tag v0.0.1 has the go modules declaring they're in `teamsnap/vault` instead of `teamsnap/vault-key`, this is necessary to get it actually working with cloud functions and everything.