### PR TITLE
PLAT-542: API for listing secret engines from vault

### DIFF
--- a/pkg/vault/engines.go
+++ b/pkg/vault/engines.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 )
 
-// EnginesFromVault takes a path and returns a list of engines from vault.
-func (vc *vaultClient) EnginesFromVault(path string) ([]string, error) {
-	vc.tracer.trace(fmt.Sprintf("%s/EnginesFromVault", vc.config.tracePrefix))
+// enginesFromVault takes a path and returns a list of engines from vault.
+func (vc *vaultClient) enginesFromVault(path string) ([]string, error) {
+	vc.tracer.trace(fmt.Sprintf("%s/enginesFromVault", vc.config.tracePrefix))
 
 	engines, err := vc.client.Logical().List(path)
 	if err != nil {

--- a/pkg/vault/engines.go
+++ b/pkg/vault/engines.go
@@ -2,17 +2,11 @@ package vault
 
 import (
 	"fmt"
-
-	"go.opencensus.io/trace"
 )
 
 // EnginesFromVault takes a path and returns a list of engines from vault.
 func (vc *vaultClient) EnginesFromVault(path string) ([]string, error) {
-	if vc.config.traceEnabled {
-		var span *trace.Span
-		vc.ctx, span = trace.StartSpan(vc.ctx, fmt.Sprintf("%s/EnginesFromVault", vc.config.tracePrefix))
-		defer span.End()
-	}
+	vc.tracer.trace(fmt.Sprintf("%s/EnginesFromVault", vc.config.tracePrefix))
 
 	engines, err := vc.client.Logical().List(path)
 	if err != nil {

--- a/pkg/vault/engines.go
+++ b/pkg/vault/engines.go
@@ -1,0 +1,39 @@
+package vault
+
+import (
+	"fmt"
+
+	"go.opencensus.io/trace"
+)
+
+// EnginesFromVault takes a path and returns a list of engines from vault.
+func (vc *vaultClient) EnginesFromVault(path string) ([]string, error) {
+	if vc.config.traceEnabled {
+		var span *trace.Span
+		vc.ctx, span = trace.StartSpan(vc.ctx, fmt.Sprintf("%s/EnginesFromVault", vc.config.tracePrefix))
+		defer span.End()
+	}
+
+	engines, err := vc.client.Logical().List(path)
+	if err != nil {
+		return nil, fmt.Errorf("listing engines from Vault for %s", path)
+	}
+
+	if engines == nil {
+		return nil, fmt.Errorf("engines returned from Vault are <nil> for %s", path)
+	}
+
+	engineData, _ := extractListData(engines)
+
+	result := []string{}
+
+	for _, value := range engineData {
+		switch v := value.(type) {
+		case string:
+			result = append(result, v)
+		default:
+			return nil, fmt.Errorf("unexpected type, expected string, got: %T, value: %v", v, result)
+		}
+	}
+	return result, nil
+}

--- a/pkg/vault/engines_test.go
+++ b/pkg/vault/engines_test.go
@@ -29,6 +29,7 @@ func TestEngines(t *testing.T) {
 		ctx:    context.Background(),
 		client: rootVaultClient,
 	}
+	vc.tracer = vc
 
 	t.Run("engine listings", testEngineListing(vc))
 }

--- a/pkg/vault/engines_test.go
+++ b/pkg/vault/engines_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestEngines(t *testing.T) {
-	secretKey = "myGithubKey"
-	secretValue = "myGithubValue"
+	secretKey, secretValue, secretEngine = "myKey", "myValue", "kv/data/delete/foo"
 
 	secrets := map[string]interface{}{
 		"data": map[string]interface{}{secretKey: secretValue},
@@ -18,7 +17,7 @@ func TestEngines(t *testing.T) {
 	cluster := createTestVault(t)
 	defer cluster.Cleanup()
 
-	_, err := cluster.Cores[0].Client.Logical().Write("kv/data/bar", secrets)
+	_, err := cluster.Cores[0].Client.Logical().Write("kv/data/delete/bar", secrets)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,8 +37,8 @@ func testEngineListing(vc *vaultClient) func(*testing.T) {
 	return func(t *testing.T) {
 		is := is.New(t)
 		expected := []string{"bar", "foo"}
-		path := "kv/metadata"
-		engines, err := vc.EnginesFromVault(path)
+		path := "kv/metadata/delete"
+		engines, err := vc.enginesFromVault(path)
 		if err != nil {
 			t.Errorf("list engines from vault, %v", err)
 		}

--- a/pkg/vault/engines_test.go
+++ b/pkg/vault/engines_test.go
@@ -1,0 +1,53 @@
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestEngines(t *testing.T) {
+	secretKey = "myGithubKey"
+	secretValue = "myGithubValue"
+
+	secrets := map[string]interface{}{
+		"data": map[string]interface{}{secretKey: secretValue},
+	}
+
+	cluster := createTestVault(t)
+	defer cluster.Cleanup()
+
+	_, err := cluster.Cores[0].Client.Logical().Write("kv/data/bar", secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootVaultClient := cluster.Cores[0].Client
+	vc := &vaultClient{
+		config: githubConfig(t),
+		ctx:    context.Background(),
+		client: rootVaultClient,
+	}
+
+	t.Run("engine listings", testEngineListing(vc))
+}
+
+func testEngineListing(vc *vaultClient) func(*testing.T) {
+	return func(t *testing.T) {
+		is := is.New(t)
+		expected := []string{"bar", "foo"}
+		path := "kv/metadata"
+		engines, err := vc.EnginesFromVault(path)
+		if err != nil {
+			t.Errorf("list engines from vault, %v", err)
+		}
+
+		if len(engines) < 1 {
+			t.Errorf("no engines returned")
+		}
+
+		is.Equal(engines, expected)
+
+	}
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -19,19 +19,9 @@ func NewVaultToken(vc *vaultClient) (string, error) {
 
 // ListEngines fills a map with the secrets engines pulled from Vault.
 func ListEngines(ctx context.Context, path string) ([]string, error) {
-	environment := os.Getenv("ENVIRONMENT")
-
-	if environment == "production" {
-		log.SetFormatter(&log.JSONFormatter{})
-		log.SetLevel(log.WarnLevel)
-	} else {
-		log.SetFormatter(&log.TextFormatter{})
-		log.SetLevel(log.TraceLevel)
-	}
-
-	config, err := loadVaultEnvironment()
+	config, err := getConfig()
 	if err != nil {
-		return nil, fmt.Errorf("load client environment: %v", err)
+		return nil, err
 	}
 
 	vc, err := NewVaultClient(ctx, config)
@@ -42,13 +32,12 @@ func ListEngines(ctx context.Context, path string) ([]string, error) {
 
 	vc.tracer.trace(fmt.Sprintf("%s/ListEngines", vc.config.tracePrefix))
 
-	engine, err := vc.EnginesFromVault(path)
+	engine, err := vc.enginesFromVault(path)
 	if err != nil {
 		return nil, fmt.Errorf("getting engines: %v", err)
 	}
 
 	return engine, nil
-
 }
 
 // GetSecrets fills a map with the values of secrets pulled from Vault.

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -40,11 +40,7 @@ func ListEngines(ctx context.Context, path string) ([]string, error) {
 		return nil, fmt.Errorf("error initializing vault client: %v", err)
 	}
 
-	if config.traceEnabled {
-		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, fmt.Sprintf("%s/ListEngines", config.tracePrefix))
-		defer span.End()
-	}
+	vc.tracer.trace(fmt.Sprintf("%s/ListEngines", vc.config.tracePrefix))
 
 	engine, err := vc.EnginesFromVault(path)
 	if err != nil {

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -146,13 +146,15 @@ func (vc *vaultClient) EnginesFromVault(path string) ([]string, error) {
 
 	result := []string{}
 
-	for key, value := range engineData {
-		fmt.Printf("key: %s, value: %v \n", key, value)
-		result = append(result, value.(string))
+	for _, value := range engineData {
+		switch v := value.(type) {
+		case string:
+			result = append(result, v)
+		default:
+			return nil, fmt.Errorf("unexpected type, expected string, got: %T, value: %v", v, result)
+		}
 	}
-
 	return result, nil
-
 }
 
 func extractListData(secret *api.Secret) ([]interface{}, bool) {

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -123,40 +123,6 @@ func (vc *vaultClient) trace(name string) func() {
 
 	return func() { defer span.End() }
 
-// EnginesFromVault takes a path and returns a list of engines from vault.
-func (vc *vaultClient) EnginesFromVault(path string) ([]string, error) {
-	if vc.config.traceEnabled {
-		var span *trace.Span
-		vc.ctx, span = trace.StartSpan(vc.ctx, fmt.Sprintf("%s/EnginesFromVault", vc.config.tracePrefix))
-		defer span.End()
-	}
-
-	engines, err := vc.client.Logical().List(path)
-	if err != nil {
-		log.Error(fmt.Sprintf("listing engines from Vault: %v", err))
-		return nil, fmt.Errorf("listing engines from Vault for %s", path)
-	}
-
-	if engines == nil {
-		log.Error("engines returned from Vault are <nil> for " + path)
-		return nil, fmt.Errorf("engines returned from Vault are <nil> for %s", path)
-	}
-
-	engineData, _ := extractListData(engines)
-
-	result := []string{}
-
-	for _, value := range engineData {
-		switch v := value.(type) {
-		case string:
-			result = append(result, v)
-		default:
-			return nil, fmt.Errorf("unexpected type, expected string, got: %T, value: %v", v, result)
-		}
-	}
-	return result, nil
-}
-
 func extractListData(secret *api.Secret) ([]interface{}, bool) {
 	if secret == nil || secret.Data == nil {
 		return nil, false

--- a/pkg/vault/vault_client.go
+++ b/pkg/vault/vault_client.go
@@ -122,6 +122,7 @@ func (vc *vaultClient) trace(name string) func() {
 	)
 
 	return func() { defer span.End() }
+}
 
 func extractListData(secret *api.Secret) ([]interface{}, bool) {
 	if secret == nil || secret.Data == nil {

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -71,6 +71,17 @@ func TestDeleteSecret(t *testing.T) {
 	is.NoErr(err)
 }
 
+func TestListEngines(t *testing.T) {
+	is := is.New(t)
+	loginServer := vaultLoginServer()
+	defer loginServer.Close()
+
+	os.Setenv("VAULT_ADDR", loginServer.URL)
+
+	_, err := vault.ListEngines(context.Background(), "data")
+	is.NoErr(err)
+}
+
 func vaultLoginServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/login") {

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -83,6 +83,7 @@ func TestListEngines(t *testing.T) {
 }
 
 func vaultLoginServer() *httptest.Server {
+	os.Setenv("GITHUB_OAUTH_TOKEN", "token")
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/login") {
 			json.NewEncoder(w).Encode(api.Secret{


### PR DESCRIPTION
### Context
- this is part of ensuring secret parity across environments. more detail on larger scope here: https://teamsnap.atlassian.net/browse/PLAT-471
- this specific piece of work is tied to: https://teamsnap.atlassian.net/browse/PLAT-542

### Description
- created function to list engines from a path in vault
- create test for engine listing
- refactored to separate both feature and test into separate `engines` files