### PR TITLE
Plat 546 fix delete

### DIFF
--- a/pkg/vault/delete.go
+++ b/pkg/vault/delete.go
@@ -10,16 +10,18 @@ import (
 func (vc *vaultClient) delete(engine, key string) (*api.Secret, error) {
 	vc.tracer.trace(fmt.Sprintf("%s/delete", vc.config.tracePrefix))
 
-	res, err := vc.SecretFromVault(engine)
+	data, err := vc.SecretFromVault(engine)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify engine %s: %w", engine, err)
 	}
 
-	if _, ok := res[key]; !ok {
+	if _, ok := data[key]; !ok {
 		return nil, fmt.Errorf("key: %s does not exist for engine at %s", key, engine)
+	} else {
+		delete(data, key)
 	}
 
-	secret, err := vc.client.Logical().Delete(engine + "/" + key)
+	secret, err := vc.write(engine, data)
 	if err != nil {
 		return secret, fmt.Errorf("failed to delete key %s at %s:%w", key, engine, err)
 	}

--- a/pkg/vault/delete_test.go
+++ b/pkg/vault/delete_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	secretKey, secretValue, secretEngine = "deletable-key", "foo", "kv/data/delete/foo"
+	secretKey, secretValue, secretEngine = "deletable-key", "value", "kv/data/delete/foo"
 
 	cluster := createTestVault(t)
 	defer cluster.Cleanup()
@@ -39,15 +39,15 @@ func delete_new(vc *vaultClient) func(*testing.T) {
 func delete_existing(vc *vaultClient) func(*testing.T) {
 	return func(t *testing.T) {
 		is := is.New(t)
-
 		engine, k := secretEngine, secretKey
+
 		_, err := vc.delete(engine, k)
 		is.NoErr(err)
 
-		secret, err := vc.SecretFromVault(engine + "/" + k)
-		is.True(err != nil)
-		_, ok := secret[k]
-		is.Equal(false, ok)
+		secret, err := vc.SecretFromVault(engine)
+		is.NoErr(err)
+		_, present := secret[k]
+		is.Equal(false, present)
 	}
 }
 

--- a/pkg/vault/engines_test.go
+++ b/pkg/vault/engines_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestEngines(t *testing.T) {
-	secretKey, secretValue, secretEngine = "myKey", "myValue", "kv/data/delete/foo"
+	secretKey, secretValue, secretEngine = "myKey", "myValue", "kv/data/list/foo"
 
 	secrets := map[string]interface{}{
 		"data": map[string]interface{}{secretKey: secretValue},
@@ -17,7 +17,7 @@ func TestEngines(t *testing.T) {
 	cluster := createTestVault(t)
 	defer cluster.Cleanup()
 
-	_, err := cluster.Cores[0].Client.Logical().Write("kv/data/delete/bar", secrets)
+	_, err := cluster.Cores[0].Client.Logical().Write("kv/data/list/bar", secrets)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func testEngineListing(vc *vaultClient) func(*testing.T) {
 	return func(t *testing.T) {
 		is := is.New(t)
 		expected := []string{"bar", "foo"}
-		path := "kv/metadata/delete"
+		path := "kv/metadata/list"
 		engines, err := vc.enginesFromVault(path)
 		if err != nil {
 			t.Errorf("list engines from vault, %v", err)

--- a/pkg/vault/trace_test.go
+++ b/pkg/vault/trace_test.go
@@ -31,8 +31,8 @@ func TestTracer(t *testing.T) {
 	}
 
 	t.Run("trace create", test_createTrace(vc))
-	t.Run("trace delete", test_deleteTrace(vc))
 	t.Run("trace update", test_updateTrace(vc))
+	t.Run("trace delete", test_deleteTrace(vc))
 	t.Run("trace new github vault token", test_newGithubVaultTokenTrace(vc))
 }
 
@@ -79,7 +79,7 @@ func test_deleteTrace(vc *vaultClient) func(*testing.T) {
 
 		val, ok := vc.tracer.(*mockTracer)
 		is.Equal(ok, true)
-		is.Equal(val.spans, map[string]bool{"vault/delete": true, "vault/SecretFromVault": true})
+		is.Equal(val.spans, map[string]bool{"vault/delete": true, "vault/SecretFromVault": true, "vault/write": true})
 	}
 }
 

--- a/pkg/vault/update.go
+++ b/pkg/vault/update.go
@@ -16,7 +16,7 @@ func (vc *vaultClient) update(engine, key, value string) (*api.Secret, error) {
 	}
 
 	if _, ok := data[key]; !ok {
-		return nil, fmt.Errorf("missing key: %s for secret at %s", key, engine)
+		return nil, fmt.Errorf("key: %s does not exist for engine at %s", key, engine)
 	} else {
 		data[key] = value
 	}


### PR DESCRIPTION
Do not use the `delete` command from vault.logical().  This command is intended to remove an entire engine, not a single secret.  Instead, grab existing secrets, remove the desired key, and write the update secret data.