### PR TITLE
fix: [ISH-293] correctly handle secrets for an engine from vault

### DIFF
--- a/cmd/vault-staging-k8s-secret/config.go
+++ b/cmd/vault-staging-k8s-secret/config.go
@@ -36,9 +36,9 @@ func newConfig(lgr *zap.Logger) *config {
 	// load optional config from environment
 	override := os.Getenv("VAULT_SECRET_OVERRIDE")
 	if len(override) < 1 {
-		lgr.Info("No override engine provided.")
+		lgr.Info("No override secret provided.")
 	} else {
-		lgr.Debug("vault-path to an overriding engine", zap.String("VAULT_SECRET_OVERRIDE", override))
+		lgr.Debug("vault-path to an overriding secret", zap.String("VAULT_SECRET_OVERRIDE", override))
 	}
 
 	return &config{

--- a/cmd/vault-staging-k8s-secret/config.go
+++ b/cmd/vault-staging-k8s-secret/config.go
@@ -2,24 +2,26 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
 type config struct {
-	defaultEngine string
-	override      string
-	k8sNamespace  string
+	engine             string
+	defaultSecretPath  string
+	overrideSecretPath string
+	k8sNamespace       string
 }
 
 func newConfig(lgr *zap.Logger) *config {
 
 	// load required config from environment
-	defaultEngine := os.Getenv("VAULT_SECRET")
+	defaultSecret := os.Getenv("VAULT_SECRET")
 	k8sNamespace := os.Getenv("K8S_NAMESPACE")
 
 	req := []string{}
-	if len(defaultEngine) < 1 {
+	if len(defaultSecret) < 1 {
 		req = append(req, ("VAULT_SECRET"))
 	}
 	if len(k8sNamespace) < 1 {
@@ -28,7 +30,7 @@ func newConfig(lgr *zap.Logger) *config {
 	if len(req) > 0 {
 		lgr.Fatal("bad configuration", zap.Strings("missing environment variables", req))
 	}
-	lgr.Debug("vault-path to the default engine", zap.String("VAULT_SECRET", defaultEngine))
+	lgr.Debug("vault-path to the default engine", zap.String("VAULT_SECRET", defaultSecret))
 	lgr.Debug("kubernetes namespace to apply secret", zap.String("K8S_NAMESPACE", k8sNamespace))
 
 	// load optional config from environment
@@ -40,8 +42,34 @@ func newConfig(lgr *zap.Logger) *config {
 	}
 
 	return &config{
-		defaultEngine: defaultEngine,
-		override:      override,
-		k8sNamespace:  k8sNamespace,
+		engine:             translatePath(defaultSecret),
+		defaultSecretPath:  defaultSecret,
+		overrideSecretPath: override,
+		k8sNamespace:       k8sNamespace,
 	}
+}
+
+// translatePath is a helper that converts a path to a vault secret
+// to a truncated path needed for the vault api engines list function
+//
+// ie staging/applications/data/foo/dotenv -> staging/applications/metadata/foo
+func translatePath(path string) string {
+	strs := strings.Split(path, "/")
+
+	for i, s := range strs {
+		if s == "data" {
+			strs[i] = "metadata"
+		}
+	}
+
+	return strings.Join(strs[:len(strs)-1], "/")
+}
+
+// getSecret is a helper that takes a path to a vault secret
+// and returns the secret
+//
+// staging/applications/data/foo/dotenv -> foo
+func getSecret(path string) string {
+	strs := strings.Split(path, "/")
+	return strs[len(strs)-1]
 }

--- a/cmd/vault-staging-k8s-secret/main.go
+++ b/cmd/vault-staging-k8s-secret/main.go
@@ -42,45 +42,64 @@ func run(ctx context.Context, lgr *zap.Logger) error {
 
 	cfg := newConfig(lgr)
 
-	engines := []string{cfg.defaultEngine}
-	if cfg.override != "" {
-		engines = append(engines, cfg.override)
+	secretsToApply := []string{cfg.defaultSecretPath}
+	if cfg.overrideSecretPath != "" {
+		secretsToApply = append(secretsToApply, cfg.overrideSecretPath)
 	}
 
-	var verifiedEngines []string
-	for _, p := range engines {
-		lgr.Debug("verifying engine exists for path", zap.String("path", p))
-		if _, err := vault.ListEngines(ctx, p); err != nil {
-			verifiedEngines = append(verifiedEngines, p)
-		} else {
-			lgr.Error("cannot verify engine exists at path", zap.Error(err))
+	var vaultSecrets []string
+	var err error
+	lgr.Debug("getting secrets for engine", zap.String("engine", cfg.engine))
+
+	// vault.ListEngines returns a list of secrets defined for an engine
+	// ie staging/applications/metadata/foo -> [dotenv, dotenv-override, etc]
+	if vaultSecrets, err = vault.ListEngines(ctx, cfg.engine); err != nil {
+		lgr.Error("cannot verify engine exists at path", zap.Error(err))
+	}
+
+	// If a secret to apply does not exist in vault, do not attempt to apply it
+	var verifiedSecrets []string
+	for _, s := range secretsToApply {
+		found := false
+
+		for _, vs := range vaultSecrets {
+			if getSecret(s) == vs {
+				lgr.Debug("secret exists", zap.String("secret", s))
+				verifiedSecrets = append(verifiedSecrets, s)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			lgr.Debug("secret does not exist", zap.String("secret", s))
 		}
 	}
 
-	lgr.Info("getting vault secrets from verified engines", zap.Strings("verified-engines", verifiedEngines))
+	lgr.Info("getting vault secrets from verified engines", zap.Strings("verified-engines", verifiedSecrets))
 	secrets := map[string]map[string]string{}
-	if err := vault.GetSecrets(ctx, &secrets, verifiedEngines); err != nil {
+	if err := vault.GetSecrets(ctx, &secrets, verifiedSecrets); err != nil {
 		return fmt.Errorf("cannot get secrets from vault: %w", err)
 	}
 
 	mergedSecrets := map[string]string{}
-	for _, e := range verifiedEngines {
-		if e == cfg.override {
+	for _, e := range verifiedSecrets {
+		if e == cfg.overrideSecretPath {
 			lgr.Info("creating overrides")
-			mergedSecrets = secrets[cfg.override]
+			mergedSecrets = secrets[cfg.overrideSecretPath]
 		}
 	}
 
 	lgr.Info("setting defaults")
-	for k, v := range secrets[cfg.defaultEngine] {
+	for k, v := range secrets[cfg.defaultSecretPath] {
 		if _, ok := mergedSecrets[k]; !ok {
 			mergedSecrets[k] = v
 		} else {
 			lgr.Debug(
-				"default value for key overriden by configuration",
+				"default value for key overridden by configuration",
 				zap.String("key", k),
 				zap.String("value", v),
-				zap.String("path", cfg.override),
+				zap.String("path", cfg.overrideSecretPath),
 			)
 		}
 	}


### PR DESCRIPTION
- added comments for clarity
- renamed defaultEngine to defaultSecret
- added helpers for getting secrets from a path
- added helper for getting metadata url from a path