### PR TITLE
chore: [PLAT-4443] move dependabot to Sundays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,48 +1,53 @@
+---
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: "/infra/docker"
-    schedule:
-      interval: daily
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 15
-    rebase-strategy: disabled
-    groups:
-      patch-updates:
-        update-types:
-          - "patch"
-  - package-ecosystem: bundler
-    directory: "/"
-    schedule:
-      interval: daily
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 15
-    rebase-strategy: disabled
-    groups:
-      patch-updates:
-        update-types:
-          - "patch"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    pull-request-branch-name:
-      separator: "-"
-    groups:
-      patch-updates:
-        update-types:
-          - "patch"
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 15
-    rebase-strategy: disabled
-    groups:
-      patch-updates:
-        update-types:
-          - "patch"
+- package-ecosystem: docker
+  directory: "/infra/docker"
+  schedule:
+    interval: weekly
+    day: sunday
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 15
+  rebase-strategy: disabled
+  groups:
+    patch-updates:
+      update-types:
+      - patch
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 15
+  rebase-strategy: disabled
+  groups:
+    patch-updates:
+      update-types:
+      - patch
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
+  pull-request-branch-name:
+    separator: "-"
+  groups:
+    patch-updates:
+      update-types:
+      - patch
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
+  pull-request-branch-name:
+    separator: "-"
+  open-pull-requests-limit: 15
+  rebase-strategy: disabled
+  groups:
+    patch-updates:
+      update-types:
+      - patch


### PR DESCRIPTION
In an effort to cut down on the noise in developer feeds,
this PR will move dependabot to run on Sundays only.
