### PR TITLE
Add configurable K8S_SECRET_NAME for versioned secret rollbacks

### DIFF
--- a/cmd/vault-k8s-secret/Dockerfile
+++ b/cmd/vault-k8s-secret/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.6-bookworm
+FROM golang:1.23.2-bookworm
 
 ENV \
  GOARCH="amd64" \
@@ -22,16 +22,18 @@ RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
 && ln -s /usr/local/google-cloud-sdk/bin/kubectl.$KUBECTL_VERSION /usr/local/bin/kubectl \
 && apt-get remove -y curl wget
 
-WORKDIR /go/src/github.com/teamsnap/vault-k8s-secret
+WORKDIR /go/src/github.com/teamsnap/vault-key
 
-COPY go.mod go.mod
+# Copy local dependency first for layer caching
+COPY pkg/k8s/ pkg/k8s/
 
-RUN go version \
- && go mod download \
- && go mod verify
+# Copy the command module
+COPY cmd/vault-k8s-secret/ cmd/vault-k8s-secret/
 
-COPY . .
+WORKDIR /go/src/github.com/teamsnap/vault-key/cmd/vault-k8s-secret
 
-RUN env GOOS=linux GOARCH=amd64 go build -o vault-k8s-secret
+RUN go mod download
 
-CMD ./entrypoint.sh
+RUN GONOSUMCHECK=* GOOS=linux GOARCH=amd64 go build -mod=mod -o vault-k8s-secret
+
+CMD ["./entrypoint.sh"]

--- a/cmd/vault-k8s-secret/Dockerfile
+++ b/cmd/vault-k8s-secret/Dockerfile
@@ -36,4 +36,8 @@ RUN go mod download
 
 RUN GONOSUMCHECK=* GOOS=linux GOARCH=amd64 go build -mod=mod -o vault-k8s-secret
 
+RUN useradd --create-home --uid 10001 appuser \
+ && chown -R appuser:appuser /go/src/github.com/teamsnap/vault-key
+USER appuser
+
 CMD ["./entrypoint.sh"]

--- a/cmd/vault-k8s-secret/config.go
+++ b/cmd/vault-k8s-secret/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/teamsnap/vault-key/pkg/k8s"
 	"go.uber.org/zap"
 )
 
@@ -11,17 +12,19 @@ type config struct {
 	engine            string
 	defaultSecretPath string
 	k8sNamespace      string
+	k8sSecretName     string
 }
 
 func newConfig(lgr *zap.Logger) *config {
 
 	// load required config from environment
-	defaultSecret := os.Getenv("VAULT_SECRET")
-	k8sNamespace := os.Getenv("K8S_NAMESPACE")
+	defaultSecret := getEnv("VAULT_SECRET", "")
+	k8sNamespace := getEnv("K8S_NAMESPACE", "")
+	k8sSecretName := getEnv("K8S_SECRET_NAME", k8s.DefaultSecretName)
 
 	req := []string{}
 	if len(defaultSecret) < 1 {
-		req = append(req, ("VAULT_SECRET"))
+		req = append(req, "VAULT_SECRET")
 	}
 	if len(k8sNamespace) < 1 {
 		req = append(req, "K8S_NAMESPACE")
@@ -31,12 +34,21 @@ func newConfig(lgr *zap.Logger) *config {
 	}
 	lgr.Debug("vault-path to the default engine", zap.String("VAULT_SECRET", defaultSecret))
 	lgr.Debug("kubernetes namespace to apply secret", zap.String("K8S_NAMESPACE", k8sNamespace))
+	lgr.Debug("kubernetes secret name", zap.String("K8S_SECRET_NAME", k8sSecretName))
 
 	return &config{
 		engine:            translatePath(defaultSecret),
 		defaultSecretPath: defaultSecret,
 		k8sNamespace:      k8sNamespace,
+		k8sSecretName:     k8sSecretName,
 	}
+}
+
+func getEnv(varName, defaultVal string) string {
+	if value, isPresent := os.LookupEnv(varName); isPresent {
+		return value
+	}
+	return defaultVal
 }
 
 // translatePath is a helper that converts a path to a vault secret

--- a/cmd/vault-k8s-secret/go.mod
+++ b/cmd/vault-k8s-secret/go.mod
@@ -9,6 +9,8 @@ require (
 	go.uber.org/zap v1.27.0
 )
 
+replace github.com/teamsnap/vault-key/pkg/k8s => ../../pkg/k8s
+
 require (
 	cel.dev/expr v0.18.0 // indirect
 	cloud.google.com/go v0.116.0 // indirect

--- a/cmd/vault-k8s-secret/logger.go
+++ b/cmd/vault-k8s-secret/logger.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"os"
 	"strings"
 
 	"go.uber.org/zap"
@@ -57,13 +56,4 @@ func newLogger(service string) (*zap.Logger, error) {
 	cfg.Level.SetLevel(lvl)
 
 	return logger, nil
-}
-
-// getEnv gets the value of an enviroinment variable named by the key.
-// If the key is not found, a fallback value is used.
-func getEnv(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
 }

--- a/cmd/vault-k8s-secret/main.go
+++ b/cmd/vault-k8s-secret/main.go
@@ -55,6 +55,7 @@ func run(ctx context.Context, lgr *zap.Logger) error {
 		&k8s.Secret{
 			Secrets:   secrets[cfg.defaultSecretPath],
 			Namespace: cfg.k8sNamespace,
+			Name:      cfg.k8sSecretName,
 		}); err != nil {
 		return fmt.Errorf("unable to apply secrets to namespace %s: %w", cfg.k8sNamespace, err)
 	}

--- a/examples/kubernetes/vault-k8s-secret/README.md
+++ b/examples/kubernetes/vault-k8s-secret/README.md
@@ -11,6 +11,25 @@ The cronjob example will sync a Vault secret with Kubernetes every hour.
 
 The job example will only run once, which might be useful as part of a CI/CD pipeline before deploying a new version of an app.
 
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `VAULT_SECRET` | Yes | | Path to the Vault secret (e.g., `staging/applications/data/myapp/dotenv`) |
+| `K8S_NAMESPACE` | Yes | | Kubernetes namespace to create the secret in |
+| `K8S_SECRET_NAME` | No | `vault-secret` | Name of the Kubernetes secret to create. Use a custom name to support versioned secrets or avoid overwriting existing secrets. |
+| `VAULT_ADDR` | Yes | | Vault server URL |
+| `VAULT_ROLE` | Yes | | Vault auth role |
+| `GCLOUD_PROJECT` | Yes | | GCP project ID |
+| `GCLOUD_REGION` | Yes | | GCP region (e.g., `us-east1`) |
+| `CLUSTER_NAME` | Yes | | GKE cluster name |
+| `FUNCTION_IDENTITY` | Yes | | GCP service account email |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Yes | | Path to the GCP SA key file inside the container |
+| `GCP_AUTH_PATH` | No | | Vault GCP auth mount path |
+| `VERBOSITY` | No | `info` | Log level: `debug`, `info`, `warn`, `error` |
+
+## Setup
+
 You'll need to replace `base64encodedjsonfile=` with the contents of your service account JSON file. You can get this value by running `cat ./path/to/service-account.json | base64`.
 
 At that point you're ready to `kubectl apply -f job.yaml` or `kubectl apply -f cronjob.yaml` and then you're good to go.

--- a/examples/kubernetes/vault-k8s-secret/cronjob.yaml
+++ b/examples/kubernetes/vault-k8s-secret/cronjob.yaml
@@ -36,6 +36,10 @@ spec:
               value: vault-role-cloud-functions
             - name: VAULT_SECRET
               value: test/data/test
+            - name: K8S_NAMESPACE
+              value: default
+            - name: K8S_SECRET_NAME
+              value: vault-secret
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account-key.json
             - name: CLUSTER_NAME

--- a/examples/kubernetes/vault-k8s-secret/job.yaml
+++ b/examples/kubernetes/vault-k8s-secret/job.yaml
@@ -33,6 +33,8 @@ spec:
           value: test/data/test
         - name: K8S_NAMESPACE
           value: default
+        - name: K8S_SECRET_NAME
+          value: vault-secret
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/service-account-key.json
         - name: CLUSTER_NAME

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -54,7 +54,7 @@ func (c Client) createSecret(ctx context.Context, secret *apiv1.Secret) (*apiv1.
 }
 
 func (c Client) getSecret(ctx context.Context, secret *apiv1.Secret) (*apiv1.Secret, error) {
-	gs, err := c.Clientset.CoreV1().Secrets(secret.Namespace).Get(ctx, "vault-secret", metav1.GetOptions{})
+	gs, err := c.Clientset.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest version of secret: %s", err)
 	}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -30,7 +30,7 @@ func TestClient(t *testing.T) {
 		is.Equal(s, nil)
 	})
 
-	t.Run("create secret sucess", func(t *testing.T) {
+	t.Run("create secret success", func(t *testing.T) {
 		is := is.New(t)
 		secret := newTestSecret()
 		c := &Client{Clientset: testclient.NewSimpleClientset()}
@@ -49,7 +49,7 @@ func TestClient(t *testing.T) {
 		is.True(err != nil)
 	})
 
-	t.Run("update secret sucess", func(t *testing.T) {
+	t.Run("update secret success", func(t *testing.T) {
 		is := is.New(t)
 		secret := newTestSecret()
 		c := &Client{Clientset: testclient.NewSimpleClientset(secret)}
@@ -68,7 +68,7 @@ func TestClient(t *testing.T) {
 		is.Equal(s, nil)
 	})
 
-	t.Run("get secret sucess", func(t *testing.T) {
+	t.Run("get secret success", func(t *testing.T) {
 		is := is.New(t)
 		secret := newTestSecret()
 		c := &Client{Clientset: testclient.NewSimpleClientset(secret)}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -10,83 +10,71 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
-func TestClient(t *testing.T) {
-	secret := &v1.Secret{
+func newTestSecret() *v1.Secret {
+	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "vault-secret",
 		},
 		Data: map[string][]byte{"key": []byte("value")},
 	}
-
-	cases := []struct {
-		name   string
-		secret *v1.Secret
-		client *Client
-		isErr  bool
-	}{
-		{
-			name:   "failure",
-			secret: secret,
-			client: &Client{Clientset: testclient.NewSimpleClientset(secret)},
-			isErr:  true,
-		},
-		{
-			name:   "sucess",
-			secret: secret,
-			client: &Client{Clientset: testclient.NewSimpleClientset()},
-			isErr:  false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run("create secret "+c.name, testCreateSecret(c.client, c.secret, c.isErr))
-		t.Run("update secret "+c.name, testUpdateSecret(c.client, c.secret, c.isErr))
-		t.Run("get secret "+c.name, testGetSecret(c.client, c.secret, c.isErr))
-	}
 }
 
-func testCreateSecret(c *Client, secret *v1.Secret, isErr bool) func(*testing.T) {
-	return func(t *testing.T) {
+func TestClient(t *testing.T) {
+	t.Run("create secret failure", func(t *testing.T) {
 		is := is.New(t)
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset(secret)}
 
 		s, err := c.createSecret(context.Background(), secret)
-		if isErr {
-			is.True(err != nil)
-			is.Equal(s, nil)
-		} else {
-			is.NoErr(err)
-		}
-	}
-}
+		is.True(err != nil)
+		is.Equal(s, nil)
+	})
 
-func testUpdateSecret(c *Client, secret *v1.Secret, isErr bool) func(*testing.T) {
-	return func(t *testing.T) {
+	t.Run("create secret sucess", func(t *testing.T) {
 		is := is.New(t)
-		if isErr {
-			secret.ObjectMeta.Name = "shrug"
-		}
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset()}
+
+		s, err := c.createSecret(context.Background(), secret)
+		is.NoErr(err)
+		is.True(s != nil)
+	})
+
+	t.Run("update secret failure", func(t *testing.T) {
+		is := is.New(t)
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset()}
 
 		err := c.updateSecret(context.Background(), secret)
-		if isErr {
-			is.True(err != nil)
-		} else {
-			is.NoErr(err)
-		}
-	}
-}
+		is.True(err != nil)
+	})
 
-func testGetSecret(c *Client, secret *v1.Secret, isErr bool) func(*testing.T) {
-	return func(t *testing.T) {
+	t.Run("update secret sucess", func(t *testing.T) {
 		is := is.New(t)
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset(secret)}
+
+		err := c.updateSecret(context.Background(), secret)
+		is.NoErr(err)
+	})
+
+	t.Run("get secret failure", func(t *testing.T) {
+		is := is.New(t)
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset()}
 
 		s, err := c.getSecret(context.Background(), secret)
+		is.True(err != nil)
+		is.Equal(s, nil)
+	})
 
-		// test result is inverted since we succeed when the secret exists
-		if !isErr {
-			is.True(err != nil)
-			is.Equal(s, nil)
-		} else {
-			is.NoErr(err)
-		}
-	}
+	t.Run("get secret sucess", func(t *testing.T) {
+		is := is.New(t)
+		secret := newTestSecret()
+		c := &Client{Clientset: testclient.NewSimpleClientset(secret)}
+
+		s, err := c.getSecret(context.Background(), secret)
+		is.NoErr(err)
+		is.True(s != nil)
+	})
 }

--- a/pkg/k8s/secret.go
+++ b/pkg/k8s/secret.go
@@ -16,10 +16,14 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
+// DefaultSecretName is the default name for the Kubernetes secret created by vault-key.
+const DefaultSecretName = "vault-secret"
+
 // Secret holds a map of the secrets that need to be created in Kubernetes
 type Secret struct {
 	Secrets   map[string]string
 	Namespace string
+	Name      string
 }
 
 // ApplySecret takes a Vault secret and k8s namespace and creates the k8s secret based on the data
@@ -47,9 +51,14 @@ func ApplySecret(vaultSecret *Secret) error {
 		secretData[key] = []byte(val)
 	}
 
+	secretName := vaultSecret.Name
+	if secretName == "" {
+		secretName = DefaultSecretName
+	}
+
 	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vault-secret",
+			Name:      secretName,
 			Namespace: vaultSecret.Namespace,
 		},
 		Data: secretData,

--- a/pkg/k8s/secret_test.go
+++ b/pkg/k8s/secret_test.go
@@ -27,10 +27,10 @@ func TestClient(t *testing.T) {
 		isErr  bool
 	}{
 		{
-			name:   "failure",
+			name:   "secret already exists",
 			secret: secret,
 			client: &k8s.Client{Clientset: testclient.NewSimpleClientset(secret)},
-			isErr:  true,
+			isErr:  false,
 		},
 		{
 			name:   "sucess",

--- a/pkg/k8s/secret_test.go
+++ b/pkg/k8s/secret_test.go
@@ -33,7 +33,7 @@ func TestClient(t *testing.T) {
 			isErr:  false,
 		},
 		{
-			name:   "sucess",
+			name:   "success",
 			secret: secret,
 			client: &k8s.Client{Clientset: testclient.NewSimpleClientset()},
 			isErr:  false,


### PR DESCRIPTION
Allow the Kubernetes secret name to be configured via K8S_SECRET_NAME env var instead of hardcoding "vault-secret". Defaults to "vault-secret" for backward compatibility. Enables pinning secrets to deployment versions for safe rollbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure the Kubernetes secret name via K8S_SECRET_NAME (defaults to "vault-secret").
* **Behavior**
  * Kubernetes secret operations now use the configured explicit secret name.
* **Tests**
  * Tests reorganized into clearer subtests and use a shared test-secret helper.
* **Chores**
  * Updated build/Docker steps and module handling; simplified logger/env handling.
* **Documentation**
  * Added environment-variable and setup docs and example manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->