### PR TITLE
fix: add GITHUB_TOKEN write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `permissions` block to the `release` job in `.github/workflows/release.yml` with `contents: write` and `issues: write`
- This fixes the `semantic-release` failures (EGITNOPERMISSION / 403) that have blocked automated releases since April 2026
- No unnecessary permissions are granted beyond what `semantic-release` requires

## Jira
[PLAT-7322](https://teamsnap.atlassian.net/browse/PLAT-7322)

## Test plan
- [ ] Merge to `main` and verify the release workflow run succeeds
- [ ] Confirm `semantic-release` can push version tags and create GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLAT-7322]: https://teamsnap.atlassian.net/browse/PLAT-7322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration to ensure proper permissions for automated release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->